### PR TITLE
Support for 3rd party S3 compatible providers

### DIFF
--- a/src/Flysystem/S3.php
+++ b/src/Flysystem/S3.php
@@ -78,7 +78,7 @@ class S3 implements FlysystemPluginInterface, ContainerFactoryPluginInterface {
     $this->prefix = $configuration['prefix'];
     $this->options = $configuration['options'];
 
-    if ($this->isCnameVirtualHosted($configuration['cname'], $this->bucket)) {
+    if ($this->isCnameVirtualHosted($configuration['cname'], $this->bucket) || $this->isNotAws($configuration)) {
       $this->urlPrefix = $configuration['protocol'] . '://' . $configuration['cname'];
     }
     else {
@@ -114,6 +114,7 @@ class S3 implements FlysystemPluginInterface, ContainerFactoryPluginInterface {
       'version' => 'latest',
       'region' => $configuration['region'],
       'credentials' => new Credentials($configuration['key'], $configuration['secret']),
+      'endpoint' => isset($configuration['endpoint']) ? $configuration['endpoint'] : null
     ]);
 
     unset($configuration['key'], $configuration['secret']);
@@ -174,6 +175,19 @@ class S3 implements FlysystemPluginInterface, ContainerFactoryPluginInterface {
    */
   private function isCnameVirtualHosted($cname, $bucket) {
     return strpos($cname, $bucket) === 0;
+  }
+
+  /**
+   * Detects if the provided configuration indicates that AWS is not used
+   *
+   * @param array $configuration
+   *   The configuration
+   *
+   * @return bool
+   *   TRUE if the CNAME does not contain amazonaws.com
+   */
+  private function isNotAws(array $configuration) {
+    return isset($configuration['endpoint']) && strpos($configuration['endpoint'], 'amazonaws.com') === false;
   }
 
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,7 +18,6 @@ while ($dir = dirname($dir)) {
 
   $previous_dir = $dir;
 
-error_log("CHECK ". $dir . '/core/tests/bootstrap.php');
   if (is_file($dir . '/core/tests/bootstrap.php')) {
     require_once $dir . '/core/tests/bootstrap.php';
     return;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,6 +18,7 @@ while ($dir = dirname($dir)) {
 
   $previous_dir = $dir;
 
+error_log("CHECK ". $dir . '/core/tests/bootstrap.php');
   if (is_file($dir . '/core/tests/bootstrap.php')) {
     require_once $dir . '/core/tests/bootstrap.php';
     return;

--- a/tests/src/Unit/Flysystem/S3Test.php
+++ b/tests/src/Unit/Flysystem/S3Test.php
@@ -72,6 +72,25 @@ class S3Test extends \PHPUnit_Framework_TestCase {
     $this->assertSame('https://s3-eu-west-1.amazonaws.com/example-bucket/foo%201.html', $plugin->getExternalUrl('s3://foo 1.html'));
   }
 
+  public function testCreateUsingNonAwsConfiguration() {
+    $container = new ContainerBuilder();
+    $container->set('request_stack', new RequestStack());
+    $container->get('request_stack')->push(Request::create('https://example.com/'));
+
+    $configuration = [
+      'key'      => 'fee',
+      'secret'   => 'fo',
+      'region'   => 'eu-west-1',
+      'bucket'   => 'example-bucket',
+      'cname'    => 'something.somewhere.tld',
+      'endpoint' => 'https://api.somewhere.tld'
+    ];
+
+    $plugin = S3::create($container, $configuration, '', '');
+    $this->assertSame('https://something.somewhere.tld/foo%201.html', $plugin->getExternalUrl('s3://foo 1.html'));
+    $this->assertSame($plugin->getAdapter()->getClient()->getEndpoint(). '', 'https://api.somewhere.tld');
+  }
+
   public function testEnsure() {
     $configuration = [
       'region' => 'eu-west-1',


### PR DESCRIPTION
The patch would allow using an alternate `endpoint` and omit to append the bucket name in the URL prefix generation if the provided CNAME is not an AWS hostname.

This would allow support for 3rd party provides, which also support the S3 API. Among others:
- Minio: https://www.minio.io/
- Riak: http://docs.basho.com/riak/cs/2.1.1/references/apis/storage/s3/
- Fortrabbit: https://help.fortrabbit.com/object-storage << my bias
